### PR TITLE
Dependency on the scheme is removed

### DIFF
--- a/resume.template
+++ b/resume.template
@@ -5,9 +5,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{#resume.basics}}{{name}}{{/resume.basics}}</title>
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
-    <link href='http://fonts.googleapis.com/css?family=Lato:400,500,600,700|Open+Sans:400,500,600,700' rel='stylesheet' type='text/css'>
+    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+    <link href='//fonts.googleapis.com/css?family=Lato:400,500,600,700|Open+Sans:400,500,600,700' rel='stylesheet' type='text/css'>
     <style>
       {{{css}}}
     </style>


### PR DESCRIPTION
There's error message by Google Chrome:

> Mixed Content: The page at 'https://artspb.me/cv/' was loaded over HTTPS, but requested an insecure stylesheet 'http://fonts.googleapis.com/css?family=Lato:400,500,600,700|Open+Sans:400,500,600,700'. This request has been blocked; the content must be served over HTTPS.

Browser doesn't allow to use insecure resources on the secured page. In such a case additional user action is required which is inconvenient. The idea of the patch is to remove explicit indication of the scheme (http or https). It will allow browser to choose scheme depending on the context.
